### PR TITLE
chore: eslint 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
             "error",
             {
                 "component": true,
-                "html": true
+                "html": false
             }
         ],
         "react/jsx-first-prop-new-line": "error",


### PR DESCRIPTION
<Type>
chore : eslint 수정

<Body>
html tag를 선언했을 때, 내용이 없으면 자동으로 self closing tag로 변환되는 것을 막기 위해 eslint의 "react/self-closing-comp"의 html을 false로 변경했다.