### PR TITLE
feat: 카카오 회원가입 적용

### DIFF
--- a/src/components/signup/SelectBox.tsx
+++ b/src/components/signup/SelectBox.tsx
@@ -1,15 +1,16 @@
 import Select, { CSSObjectWithLabel } from 'react-select';
 import { Control, Controller } from 'react-hook-form';
 import { SelectOptions } from '@/data/SignUpData';
-import { useId } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { InputType, ItemType } from './type';
 
 interface propsType {
     control: Control<InputType, boolean>;
     data: ItemType;
+    defaultValue?: string;
 }
 
-const SelectBox = ({ control, data }: propsType) => {
+const SelectBox = ({ control, data, defaultValue }: propsType) => {
     const selectStyle = {
         placeholder: (baseStyles: CSSObjectWithLabel) => ({
             ...baseStyles,
@@ -34,6 +35,16 @@ const SelectBox = ({ control, data }: propsType) => {
         }),
     };
 
+    const [gender, setGender] = useState<string>();
+
+    useEffect(() => {
+        if (defaultValue === 'male') {
+            setGender('남자');
+        } else if (defaultValue === 'female') {
+            setGender('여자');
+        }
+    }, []);
+
     return (
         <Controller
             name={data.inputValue}
@@ -42,12 +53,13 @@ const SelectBox = ({ control, data }: propsType) => {
             render={({ field: { onChange } }) => (
                 <Select
                     styles={selectStyle}
-                    placeholder={data.explanation}
+                    placeholder={gender || data.explanation}
                     onChange={e => {
                         onChange(e?.value);
                     }}
                     options={SelectOptions}
                     instanceId={useId()}
+                    isDisabled={gender ? true : false}
                 />
             )}
         />

--- a/src/components/signup/kakao/index.tsx
+++ b/src/components/signup/kakao/index.tsx
@@ -1,17 +1,21 @@
+import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/router';
+import { useSelector } from 'react-redux';
 import { SU } from '../style';
 import { InputType, ErrorType } from '../type';
 import { AgreeData } from '@/data/SignUpData';
 import { SignupKakaoData } from '@/data/SignUpKakaoData';
 import { LocalNickname, LocalSignUp } from '@/apis/auth';
-import InfoInput from '@/common/molecules/InfoInput';
+import { RootState } from '@/store/store';
 import SelectBox from '../SelectBox';
+import InfoInput from '@/common/molecules/InfoInput';
 import SubmitButton from '@/common/molecules/SubmitButton';
 import ErrorMessage from '@/common/molecules/ErrorMessage';
 
 const SignUpKakao = () => {
+    const { user } = useSelector((value: RootState) => value);
+
     const {
         control,
         register,
@@ -20,6 +24,9 @@ const SignUpKakao = () => {
         setError,
     } = useForm<InputType>({
         mode: 'onChange',
+        defaultValues: {
+            email: user.userEmail,
+        },
     });
     const router = useRouter();
 
@@ -112,7 +119,7 @@ const SignUpKakao = () => {
                             {el.essential ? '*' : ''}
                         </SU.InputTitle>
                         {el.inputValue === 'gender' ? (
-                            <SelectBox control={control} data={el} />
+                            <SelectBox control={control} data={el} defaultValue={user.userGender} />
                         ) : (
                             <InfoInput
                                 inputType={el.inputType}

--- a/src/components/signup/type.ts
+++ b/src/components/signup/type.ts
@@ -16,7 +16,7 @@ type InputType = {
     password: string;
     passwordCheck: string;
     nickname: string;
-    gender: boolean | undefined;
+    gender: string | undefined;
     height: number;
     weight: number;
     squat: number;


### PR DESCRIPTION
## Title #69 

- feat: 카카오 회원가입 적용

<br>

## Description

- feat: 카카오 회원가입 적용. 
   카카오 로그인 시 db에 존재하지 않는 회원 -> 회원가입 페이지로 이동(이메일, 성별 제공)
   성별 값이 undefined -> 회원가입 페이지 내에서 성별 입력해야 회원가입 가능 

<br>
