### PR TITLE
fix: 갱신된 토큰 반영 안되는 문제 수정

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -6,12 +6,6 @@ const REDIRECT_URI = 'http://localhost:3000/verifying';
 
 export const KAKAO_API_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
-let ACCESS_TOKEN;
-
-if (typeof window !== 'undefined') {
-    ACCESS_TOKEN = localStorage.getItem('access_token');
-}
-
 export const updateToken = axios.create({
     baseURL: API_URL,
 });
@@ -27,9 +21,19 @@ export const tokenInstance = axios.create({
     baseURL: API_URL,
     headers: {
         'Content-Type': 'application/json; charset=utf-8;',
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
 });
+
+tokenInstance.interceptors.request.use(
+    config => {
+        config.headers.Authorization = `Bearer ${localStorage.getItem('access_token')}`;
+
+        return config;
+    },
+    error => {
+        return Promise.reject(error);
+    },
+);
 
 tokenInstance.interceptors.response.use(
     response => {
@@ -37,9 +41,10 @@ tokenInstance.interceptors.response.use(
     },
     async error => {
         const { config, response } = error;
+        const { status } = response;
         const { message } = response.data;
 
-        if (response.status === 401) {
+        if (status === 401) {
             if (message === '액세스 토큰이 만료되었습니다.') {
                 const refreshToken = getRefreshToken();
 


### PR DESCRIPTION
## Title #77 
- 갱신된 토큰 반영 안되는 문제 수정

## Description
원인
- client.ts에 있는 "ACCESS_TOKEN"이라는 변수에 localStorage에서 불러온 jwt를 저장하는 방법으로 로직을 구현했다. 이 방식은 갱신된 jwt는 가져오지 못했고, 갱신되기 전 jwt를 headers에 넣어 요청을 하게 된다. 그러므로 localStorage에 갱신된 jwt를 저장해도 api 요청을 할 때는 갱신된 jwt를 가져오지 못했고 브라우저의 "Network" 탭에서는 api를 요청할 때마다 [ 실패한요청 -> newToken(jwt 갱신 api) -> 성공한요청 ] 이런식으로 나오게 됐다. 

해결
- axios의 interceptors 메소드를 사용하여 요청하기 전에 localStorage에서 가져온 갱신된 jwt를 headers에 넣는다.