### PR TITLE
Refactor/119 home add button refactor

### DIFF
--- a/src/common/molecules/RoutineCard.tsx
+++ b/src/common/molecules/RoutineCard.tsx
@@ -4,27 +4,16 @@ import { useRouter } from 'next/router';
 
 import LikeControl from './LikeControl';
 
-import { SaveRoutineInfo } from '@/apis/auth';
-import getErrorMessage from '@/utils/getErrorMessage';
 import deleteBlank from '@/utils/deleteBlank';
 
 import { RC } from './style';
+
 import { RoutineProps } from './type';
 
-const RoutineCard = ({ id, imgpath, period, fewTime, routineName, category, weekProgress }: RoutineProps) => {
+const RoutineCard = ({ id, imgpath, period, enrolled, fewTime, routineName, category, weekProgress, handleButton }: RoutineProps) => {
     const pathName = useRouter().asPath;
 
     const DeletedBlankRoutineName = deleteBlank({ routineName });
-
-    const handleSaveRoutine = async (routineId: number | undefined) => {
-        try {
-            const response = await SaveRoutineInfo(routineId);
-
-            return response.data;
-        } catch (e) {
-            throw new Error(getErrorMessage(e));
-        }
-    };
 
     return (
         <RC.CardBox>
@@ -54,8 +43,10 @@ const RoutineCard = ({ id, imgpath, period, fewTime, routineName, category, week
                         </RC.CoachNameWrapper>
                         <RC.ClickWrapper>
                             <LikeControl routineId={id} />
-                            <RC.BtnWrapper>
-                                <RC.AddBtn onClick={() => handleSaveRoutine(id)}>추 가</RC.AddBtn>
+                            <RC.BtnWrapper enrolled={enrolled}>
+                                <RC.AddBtn onClick={() => handleButton?.(id)} disabled={enrolled}>
+                                    추 가
+                                </RC.AddBtn>
                             </RC.BtnWrapper>
                         </RC.ClickWrapper>
                     </RC.DescFooterWrapper>

--- a/src/common/molecules/style.ts
+++ b/src/common/molecules/style.ts
@@ -219,7 +219,7 @@ const RC = {
         display: flex;
         justify-content: end;
     `,
-    BtnWrapper: styled.div`
+    BtnWrapper: styled.div<StyledProps>`
         width: 4.375rem;
         height: 1.5625rem;
         background-color: ${({ enrolled }) => (enrolled ? '#e1e2e3' : '#317aee')};

--- a/src/common/molecules/style.ts
+++ b/src/common/molecules/style.ts
@@ -222,7 +222,7 @@ const RC = {
     BtnWrapper: styled.div`
         width: 4.375rem;
         height: 1.5625rem;
-        background-color: #317aee;
+        background-color: ${({ enrolled }) => (enrolled ? '#e1e2e3' : '#317aee')};
         border-radius: 0.3125rem;
     `,
     AddBtn: styled.button`

--- a/src/common/molecules/type.ts
+++ b/src/common/molecules/type.ts
@@ -8,18 +8,21 @@ type ItemType = {
     pageRoot: string;
 };
 interface StyledProps extends HTMLAttributes<HTMLDivElement> {
-    emailMargin: boolean | undefined;
-    pwMargin: boolean | undefined;
+    emailMargin?: boolean | undefined;
+    pwMargin?: boolean | undefined;
+    enrolled?: boolean;
 }
 
 type RoutineProps = {
     id?: number | undefined;
     imgpath: string;
     period?: number;
+    enrolled?: boolean;
     fewTime?: number;
     routineName?: string;
     category?: string;
     weekProgress?: number;
+    handleButton?: (id: number | undefined) => void;
 };
 
 export type { ItemType, StyledProps, RoutineProps };

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -6,12 +6,13 @@ import SmallSelect from '@/common/molecules/SmallSelect';
 import RoutineCard from '@/common/molecules/RoutineCard';
 import BottomBar from '@/common/molecules/BottomBar';
 
-import { SelectOptions } from '@/data/SaveData';
+import { SaveRoutineInfo } from '@/apis/auth';
 import { tokenInstance } from '@/apis/client';
+import getErrorMessage from '@/utils/getErrorMessage';
+import { SelectOptions } from '@/data/SaveData';
 
 import { H } from './style';
 import OurfitLogo from '../../../public/assets/Ourfit_logo.svg';
-import getErrorMessage from '@/utils/getErrorMessage';
 
 const Home = () => {
     const [routineList, setRoutineList] = useState([]);
@@ -27,6 +28,16 @@ const Home = () => {
             const { result } = response.data;
 
             setRoutineList(result);
+        } catch (e) {
+            throw new Error(getErrorMessage(e));
+        }
+    };
+
+    const handleSaveRoutine = async (routineId: number | undefined) => {
+        try {
+            const response = await SaveRoutineInfo(routineId);
+
+            return response.data;
         } catch (e) {
             throw new Error(getErrorMessage(e));
         }
@@ -57,8 +68,18 @@ const Home = () => {
                 <SmallSelect placeholder={'운동종목'} options={SelectOptions} handleChangeCategory={handleChangeCategory} />
             </H.SelectBox>
             <H.RoutineListBox>
-                {routineList.map(({ id, imgpath, period, fewTime, routineName, category }) => (
-                    <RoutineCard key={id} id={id} imgpath={imgpath} period={period} fewTime={fewTime} routineName={routineName} category={category} />
+                {routineList.map(({ id, imgpath, period, enrolled, fewTime, routineName, category }) => (
+                    <RoutineCard
+                        key={id}
+                        id={id}
+                        imgpath={imgpath}
+                        period={period}
+                        enrolled={enrolled}
+                        fewTime={fewTime}
+                        routineName={routineName}
+                        category={category}
+                        handleButton={handleSaveRoutine}
+                    />
                 ))}
             </H.RoutineListBox>
             <H.BottomButtonWrapper>


### PR DESCRIPTION
## Title #119 
- "/home" 추가 버튼 refactor

## Description
기존
   - 공통 컴포넌트인 RoutineCard 컴포넌트에 onClick 함수를 정의했다.

변경사항
   - 함수 정의는 RoutineCard 컴포넌트를 사용하는 페이지에서 하고, 공통컴포넌트 
      는 props로 onClick 함수를 호출만 해주게 변경
