### PR TITLE
Save 페이지 루틴 삭제 클릭시 로딩 모달 추가

### DIFF
--- a/src/common/layout/DefaultLayout.tsx
+++ b/src/common/layout/DefaultLayout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from 'react';
 import { useRouter } from 'next/router';
-import { DL } from './style';
+
 import PrevButton from '../molecules/PrevButton';
+
+import { DL } from './style';
 
 interface propsType {
     children: ReactNode;
@@ -20,6 +22,8 @@ const DefaultLayout = ({ children }: propsType) => {
                 ''
             )}
             <DL.SecondContainer>{children}</DL.SecondContainer>
+            <div id="back-drop"></div>
+            <div id="portal"></div>
         </DL.PageLayout>
     );
 };

--- a/src/common/molecules/BackDrop.tsx
+++ b/src/common/molecules/BackDrop.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { BD } from './style';
+
+const BackDrop = () => {
+    return <BD.Box />;
+};
+
+export default BackDrop;

--- a/src/common/molecules/RoutineModal.tsx
+++ b/src/common/molecules/RoutineModal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { ClipLoader } from 'react-spinners';
+
+import { RM } from './style';
+
+const override: React.CSSProperties = {
+    display: 'flex',
+    margin: '0 auto',
+    textAlign: 'center',
+    width: '3.125rem',
+    height: '3.125rem',
+};
+
+const RoutineModal = () => {
+    return (
+        <RM.Box>
+            <ClipLoader color="#36d7b7" loading={true} cssOverride={override} />
+        </RM.Box>
+    );
+};
+
+export default RoutineModal;

--- a/src/common/molecules/style.ts
+++ b/src/common/molecules/style.ts
@@ -329,4 +329,26 @@ const PP = {
     `,
 };
 
-export { LI, II, TI, SB, CB, BB, RC, PC, EM, PB, LC, PP };
+const RM = {
+    Box: styled.div`
+        z-index: 11;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    `,
+};
+
+const BD = {
+    Box: styled.div`
+        z-index: 10;
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        background: rgba(11, 19, 30, 0.37);
+        backdrop-filter: blur(0.0938rem);
+    `,
+};
+
+export { LI, II, TI, SB, CB, BB, RC, PC, EM, PB, LC, PP, RM, BD };

--- a/src/components/save/index.tsx
+++ b/src/components/save/index.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Image from 'next/image';
 
 import SmallSelect from '@/common/molecules/SmallSelect';
 import RoutineCard from '@/common/molecules/RoutineCard';
 import BottomBar from '@/common/molecules/BottomBar';
+import RoutineModal from '@/common/molecules/RoutineModal';
+import BackDrop from '@/common/molecules/BackDrop';
 
 import { DeleteRoutine, MainSave } from '@/apis/auth';
 import { SelectOptions } from '@/data/SaveData';
@@ -12,10 +15,14 @@ import getErrorMessage from '@/utils/getErrorMessage';
 import { SV } from './style';
 import WeightIcon from '../../../public/assets/weight-icon.svg';
 import { RoutineProps } from '../../common/molecules/type';
+import { ModalType } from './type';
 
 const Save = () => {
     const [selectedValue, setSelectedValue] = useState<string>('all');
     const [saveData, setSaveData] = useState<RoutineProps[]>([]);
+    const [deleteResponse, setDeleteResponse] = useState(false);
+    const [portalElement, setPortalElement] = useState<ModalType>(null);
+    const [backDropElement, setBackDropElement] = useState<ModalType>(null);
 
     const handleSave = async (category: string) => {
         try {
@@ -29,9 +36,10 @@ const Save = () => {
     };
 
     const handleDeleteRoutine = async (id: number | undefined) => {
+        setDeleteResponse(true);
         try {
             const response = await DeleteRoutine(id);
-
+            setDeleteResponse(false);
             handleSave(selectedValue);
 
             return response;
@@ -43,6 +51,11 @@ const Save = () => {
     const handleChangeCategory = (categoryData: string) => {
         setSelectedValue(categoryData);
     };
+
+    useEffect(() => {
+        setPortalElement(document.getElementById('portal'));
+        setBackDropElement(document.getElementById('back-drop'));
+    }, []);
 
     useEffect(() => {
         handleSave(selectedValue);
@@ -81,6 +94,8 @@ const Save = () => {
             <SV.ButtonWrapper>
                 <BottomBar />
             </SV.ButtonWrapper>
+            {portalElement && deleteResponse ? createPortal(<RoutineModal />, portalElement) : null}
+            {backDropElement && deleteResponse ? createPortal(<BackDrop />, backDropElement) : null}
         </SV.Box>
     );
 };

--- a/src/components/save/type.ts
+++ b/src/components/save/type.ts
@@ -36,4 +36,6 @@ type SetsType = {
     id: number;
 };
 
-export type { SelectType, RoutineType, TodayExercisesType };
+type ModalType = Element | null;
+
+export type { SelectType, RoutineType, TodayExercisesType, ModalType };


### PR DESCRIPTION
## Title #175 
- Save 페이지 루틴 삭제 클릭시 로딩 모달 추가

## Description
### 로딩 모달 추가하게된 이유
Save 페이지에서 루틴 삭제버튼 클릭시 딜레이가 생긴 후에 삭제되는 문제 발생

https://github.com/0urFit/OurFit_client/assets/55657931/68b2d0fc-2d6c-4f58-8e77-14e5dfb0abea

### 원인 
삭제 api 요청해도 DB에서 삭제되는 동안 delay가 생기기 떄문

### 해결하기 위한 고민
삭제버튼 클릭시에 바로 삭제가 안된다면 사용자 입장에서 연속해서 삭제버튼을 클릭하여 예기치 못한 버그가 생길 수 있다.

이를 해결하기 위해 두가지 방법을 생각헸다
1. api 호출하는데 있어 throttling을 적용하여 일정시간 동안은 단 한번의 호출만 일어나게 하는 방법
2. 로딩 모달을 추가하는 방법

1번 방법은 UX 측면에서는 좋지 않은 방법이라 생각했다.
개발자 입장에서는 "일정 시간동안 api 호출을 단 한번만 할 수 있어!! 문제해결" 이라고
생각하지만 사용자는 UI를 보고 정보를 판단하기 때문에 삭제 버튼을 클릭한 사용자 입장에서는 "왜 바로 반영이 안되는거지 문제가 있나?"라고 생각할 수 있다. 2번 방법을 채택한 이유다.

### 해결
백엔드와 회의를 통해 밑에와 같은 방식으로 변경하였다.

기존 : 삭제 api 호출 -> 응답 -> DB에서 삭제//DB에서 삭제 되기전 응답이 먼저오는경우
개선 : 삭제 api 호출 -> DB에서 삭제 완료 -> 응답
"DB에서 삭제 완료" 과정이 진행되는 동안 로딩 모달을 보여준다.

https://github.com/0urFit/OurFit_client/assets/55657931/0f938e04-7b06-4765-95f7-09e04db9ef6d


