### PR TITLE
Feaet/177 logout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,16 +23,7 @@
             }
         ],
         "react/jsx-first-prop-new-line": "error",
-        "comma-dangle": [
-            "error",
-            {
-                "arrays": "always-multiline",
-                "objects": "always-multiline",
-                "imports": "never",
-                "exports": "never",
-                "functions": "never"
-            }
-        ],
+        "comma-dangle": "off",
         "react/react-in-jsx-scope": "off",
         "indent": ["error", 4],
         "quotes": ["error", "single"],

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,4 +1,3 @@
-/* eslint-disable comma-dangle */
 import { manageRefreshToken } from '@/utils/manageCookie';
 import { manageAccessToken } from '@/utils/manageLocalStorage';
 import axios from 'axios';

--- a/src/components/mypage/LogoutButton.tsx
+++ b/src/components/mypage/LogoutButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+import { manageAccessToken } from '@/utils/manageLocalStorage';
+import { manageRefreshToken } from '@/utils/manageCookie';
+
+import { MP } from './style';
+
+const LogoutButton = () => {
+    const router = useRouter();
+
+    const handleLogout = () => {
+        manageAccessToken.REMOVE();
+        manageRefreshToken.REMOVE();
+
+        router.push('/');
+    };
+
+    return (
+        <MP.LogoutWrapper>
+            <MP.LogoutButton onClick={handleLogout}>로그아웃</MP.LogoutButton>
+        </MP.LogoutWrapper>
+    );
+};
+
+export default LogoutButton;

--- a/src/components/mypage/index.tsx
+++ b/src/components/mypage/index.tsx
@@ -8,6 +8,7 @@ import { GetLikedRoutine, GetUserInfo, SaveRoutineInfo } from '@/apis/auth';
 import getErrorMessage from '@/utils/getErrorMessage';
 
 import { MP } from './style';
+import LogoutButton from './LogoutButton';
 
 const Mypage = () => {
     const [routineCardList, setRoutineCardList] = useState([]);
@@ -139,6 +140,7 @@ const Mypage = () => {
                     ))}
                 </MP.LikeContentsBox>
             </MP.LikeListBox>
+            <LogoutButton />
             <MP.BottomWrapper>
                 <BottomBar />
             </MP.BottomWrapper>

--- a/src/components/mypage/style.ts
+++ b/src/components/mypage/style.ts
@@ -39,6 +39,7 @@ const MP = {
     LikeListBox: styled.div`
         width: 100%;
         height: 16.8125rem;
+        margin-bottom: 0.625rem;
     `,
     LikeHeader: styled.div`
         display: flex;
@@ -60,6 +61,16 @@ const MP = {
     LikeContentsBox: styled.div`
         height: 14.375rem;
         overflow-y: hidden;
+    `,
+    LogoutWrapper: styled.div`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    `,
+    LogoutButton: styled.button`
+        font-size: 0.875rem;
+        font-weight: bold;
+        color: red;
     `,
 };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,7 +28,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
         <>
             <GlobalStyle />
             <Component {...pageProps} />
-        </>
+        </>,
     );
 }
 

--- a/src/pages/home/detail/[slug].tsx
+++ b/src/pages/home/detail/[slug].tsx
@@ -3,7 +3,6 @@ import { DL } from '@/common/layout/style';
 import PrevButton from '@/common/molecules/PrevButton';
 import HomeDetail from '@/components/home/detail';
 import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType } from 'next/types';
-import wrapper from '@/store/store';
 
 const HomeDetailPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     return <HomeDetail props={props} />;
@@ -20,8 +19,18 @@ HomeDetailPage.getLayout = function getLayout(page: ReactElement) {
     );
 };
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(store => async (ctx: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
     const { routineId, liked } = ctx.query;
+    const { cookies } = ctx.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
 
     const assure_routine_id = routineId as string;
     const assure_routine_liked = liked as string;
@@ -35,6 +44,6 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
             converted_routine_liked,
         },
     };
-});
+};
 
 export default HomeDetailPage;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,7 +1,26 @@
 import Home from '@/components/home';
 
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
+
 const HomePage = () => {
     return <Home />;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+    const { cookies } = context.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
 };
 
 export default HomePage;

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,7 +1,26 @@
 import Mypage from '@/components/mypage';
 
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
+
 const ProfilePage = () => {
     return <Mypage />;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+    const { cookies } = context.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
 };
 
 export default ProfilePage;

--- a/src/pages/mypage/likes/index.tsx
+++ b/src/pages/mypage/likes/index.tsx
@@ -1,7 +1,10 @@
 import { ReactElement } from 'react';
+
 import { DL } from '@/common/layout/style';
 import PrevButton from '@/common/molecules/PrevButton';
 import MypageLikes from '@/components/mypage/likes';
+
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
 
 const MyPageLikesPage = () => {
     return <MypageLikes />;
@@ -16,6 +19,23 @@ MyPageLikesPage.getLayout = function getLayout(page: ReactElement) {
             {page}
         </DL.PageLayout>
     );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+    const { cookies } = context.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
 };
 
 export default MyPageLikesPage;

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,7 +1,26 @@
 import Posts from '@/components/posts';
 
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
+
 const PostPage = () => {
     return <Posts />;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+    const { cookies } = context.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
 };
 
 export default PostPage;

--- a/src/pages/save/detail/[slug].tsx
+++ b/src/pages/save/detail/[slug].tsx
@@ -3,7 +3,6 @@ import { ReactElement } from 'react';
 import { DL } from '@/common/layout/style';
 import PrevButton from '@/common/molecules/PrevButton';
 import SaveDetail from '@/components/save/detail';
-import wrapper from '@/store/store';
 
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next/types';
 import { GetServerSidePropsContext } from 'next/types';
@@ -23,10 +22,21 @@ SaveDetailPage.getLayout = function getLayout(page: ReactElement) {
     );
 };
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (ctx: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
+    const { cookies } = ctx.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
     return {
         props: { data: ctx.query },
     };
-});
+};
 
 export default SaveDetailPage;

--- a/src/pages/save/index.tsx
+++ b/src/pages/save/index.tsx
@@ -1,7 +1,25 @@
 import Save from '@/components/save';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
 
 const SavePage = () => {
     return <Save />;
+};
+
+export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
+    const { cookies } = context.req;
+
+    if (!cookies.refresh_token) {
+        return {
+            redirect: {
+                destination: '/',
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
 };
 
 export default SavePage;


### PR DESCRIPTION
## Title #177 
- 로그아웃 기능 추가

## Description

### 로그아웃 기능 check list
1. 모든 페이지에서 refresh-token 존재 유/무를 검사해야한다.
   렌더링이 된 이후에 refresh-token 존재 유/무 검사 하는 것이 아닌
   렌더링 전에 즉, 서버 사이드에서 검사해야한다. 그렇지 않으면 컴포넌트가 사용자에게 보여진 후에 redirect가 발생한다.
   - 없으면 '/' 경로로 redirect
2. '로그아웃'버튼 클릭 후 '/' 경로로 이동
3. access-token, refresh-token 삭제
    
1번 : 모든 페이지에서 getServerSideProps를 사용해 refresh-token 존재 유/무 판단
2번, 3번 : manageRefreshToke 유틸 함수로 처리 후 redirect

## 개선사항
1번
- 모든 페이지에서 getServerSideProps를 사용하여 토큰 존재 유/무 검사(이하 검사로직)
  - 이런 방식으로 처리하면 페이지가 10개 20개 더 많아져도 각 페이지 마다 검사로직을 달아줘야 하므로
     비효율 적이라고 생각된다.