### PR TITLE
 http 401 코드일 때, 토큰 재발급

### DIFF
--- a/src/apis/type.ts
+++ b/src/apis/type.ts
@@ -1,0 +1,3 @@
+export type ServiceErrorMessage = {
+    message: string;
+};


### PR DESCRIPTION
## Title #179 
- http 401 코드일 때, 토큰 재발급

## Description
전
- 401 코드이고 message까지 일치해야 access token 업데이트를 시켜줬다. 이렇게 하면 문제점이 message마다 분기 처리를 해야한다는것이다.
후
-  http 401이면 권한 문제에 대한 모든 에러를 말하는 것이니 message 일치부분 삭제

## etc
- error response type 정의