### PR TITLE
검증 페이지 history stack에 쌓이지 않게

### DIFF
--- a/src/components/loading/index.tsx
+++ b/src/components/loading/index.tsx
@@ -31,10 +31,10 @@ const Loading = ({ props: { verifyingPageProps, SocialLoginCancelMessage } }: In
             manageRefreshToken.SET(refreshToken);
 
             if (success) {
-                router.push('/home');
+                router.replace('/home');
             } else {
                 dispatch(saveUserInfo(userInfo));
-                router.push('/signup/kakao');
+                router.replace('/signup/kakao');
             }
         }
     }, []);


### PR DESCRIPTION
## Title #198 
- 검증 페이지 history stack에 쌓이지 않게

## Description
- 카카오 로그인 버튼 클릭 후, 카카오 아이디로 회원가입한 기록이 있는 사용자인지 판단하기 위해 Verifying page로 redirect 시킨다.
  이때 Verifying page에서 /home 또는 /signup/kakao 경로로 보내주기 위해 useRouter.push() 메소드를 사용하기 때문에 
  history stack에 쌓이기 때문에 /home 또는 /signup/kakao 페이지에서 뒤로가기 하면 Verifying Page로 가게 되는 문제가 생긴다
 이를 해결하기 위해 replace 메소드를 사용하여 해결