### PR TITLE
Design/216 savedetail pagination day color

### DIFF
--- a/src/common/molecules/PagiNation.tsx
+++ b/src/common/molecules/PagiNation.tsx
@@ -34,6 +34,8 @@ const DayBtn = styled.button<StyledProps>`
     border-radius: 50%;
     background-color: ${({ $today }) => $today && '#3179ee'};
 `;
-const Day = styled.span``;
+const Day = styled.span`
+    color: #000;
+`;
 
 export default PagiNation;


### PR DESCRIPTION
## Title #216 
- savedetail 페이지 pagination 글자색 변경

## Description
- 웹으로 ourfit 접속 시에 pagination 배경색과 글자색이 같아 지는 현상이 생겨 요일 color 지정
