### PR TITLE
feat: /mypage/likes에서 루틴카드 클릭시 /home/detail로 이동

### DIFF
--- a/src/common/molecules/RoutineCard.tsx
+++ b/src/common/molecules/RoutineCard.tsx
@@ -40,7 +40,7 @@ const RoutineCard = ({ id, imgpath, period, enrolled, fewTime, routineName, cate
                 <RC.DescWrapper>
                     <Link
                         href={{
-                            pathname: `${pathName}/detail/[slug]`,
+                            pathname: `${pathName === '/mypage/likes' && '/home'}/detail/[slug]`,
                             query: { slug: DeletedBlankRoutineName, routineId: id, period, weekProgress },
                         }}
                     >


### PR DESCRIPTION
## Title #218 
- /mypage/likes에서 루틴카드 클릭시 /home/detail로 이동

## Description
기존
- /mypage/likes에서 루틴카드 클릭시 404 페이지

수정후
- /mypage/likes에서 루틴카드 클릭시 /home/detail로 redirect
