### PR TITLE
redux toolkit legacy update, 카카오 회원가입 후 '/' 경로로 이동 안되는 버그

### DIFF
--- a/src/components/loading/index.tsx
+++ b/src/components/loading/index.tsx
@@ -27,10 +27,10 @@ const Loading = ({ props: { verifyingPageProps, SocialLoginCancelMessage } }: In
         } else {
             const { accessToken, refreshToken, success, userInfo } = verifyingPageProps;
 
-            manageAccessToken.SET(accessToken);
-            manageRefreshToken.SET(refreshToken);
-
             if (success) {
+                manageAccessToken.SET(accessToken);
+                manageRefreshToken.SET(refreshToken);
+
                 router.replace('/home');
             } else {
                 dispatch(saveUserInfo(userInfo));

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { AppProps } from 'next/app';
 import type { NextPage } from 'next';
 
 import GlobalStyle from '@/styles/GlobalStyle';
-import wrapper from '@/store/store';
+import { Providers } from '@/store/Providers';
 
 export type NextPageWithLayout = NextPage & {
     getLayout?: (page: ReactElement) => ReactNode;
@@ -19,9 +19,11 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
     return getLayout(
         <>
             <GlobalStyle />
-            <Component {...pageProps} />
+            <Providers>
+                <Component {...pageProps} />
+            </Providers>
         </>,
     );
 }
 
-export default wrapper.withRedux(App);
+export default App;

--- a/src/pages/verifying/index.tsx
+++ b/src/pages/verifying/index.tsx
@@ -1,16 +1,17 @@
+import axios from 'axios';
+
 import { SocialKakaoLogin } from '@/apis/auth';
 import { ServiceErrorMessage } from '@/apis/type';
 import Loading from '@/components/loading';
 import { VerifyingPagePropsType } from '@/components/loading/type';
-import wrapper from '@/store/store';
-import axios from 'axios';
+
 import { GetServerSidePropsContext, GetServerSideProps, InferGetServerSidePropsType } from 'next/types';
 
 const VerifyingPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     return <Loading props={props} />;
 };
 
-export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps(() => async (ctx: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
     const { code, error_description } = ctx.query;
 
     const KAKAO_CODE = code as string;
@@ -58,6 +59,6 @@ export const getServerSideProps: GetServerSideProps = wrapper.getServerSideProps
             SocialLoginCancelMessage,
         },
     };
-});
+};
 
 export default VerifyingPage;

--- a/src/store/Providers.tsx
+++ b/src/store/Providers.tsx
@@ -1,0 +1,6 @@
+import { store } from './store';
+import { Provider } from 'react-redux';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+}

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -24,4 +24,4 @@ const authSlice = createSlice({
 });
 
 export const { setAccessToken } = authSlice.actions;
-export default authSlice;
+export default authSlice.reducer;

--- a/src/store/slices/periodSlice.ts
+++ b/src/store/slices/periodSlice.ts
@@ -21,4 +21,4 @@ const periodSlice = createSlice({
 });
 
 export const { setWeek } = periodSlice.actions;
-export default periodSlice;
+export default periodSlice.reducer;

--- a/src/store/slices/routineSlice.ts
+++ b/src/store/slices/routineSlice.ts
@@ -36,4 +36,4 @@ const routineSlice = createSlice({
 });
 
 export const { saveRoutineInfo } = routineSlice.actions;
-export default routineSlice;
+export default routineSlice.reducer;

--- a/src/store/slices/userSlice.ts
+++ b/src/store/slices/userSlice.ts
@@ -23,4 +23,4 @@ const userSlice = createSlice({
 });
 
 export const { saveUserInfo } = userSlice.actions;
-export default userSlice;
+export default userSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,53 +1,19 @@
-/* eslint-disable indent */
+import { configureStore } from '@reduxjs/toolkit';
 
-import { configureStore, Reducer, AnyAction, CombinedState } from '@reduxjs/toolkit';
-import { HYDRATE, createWrapper } from 'next-redux-wrapper';
-import { combineReducers } from 'redux';
+import authSlice from './slices/authSlice';
+import periodSlice from './slices/periodSlice';
+import routineSlice from './slices/routineSlice';
+import userSlice from './slices/userSlice';
 
-import authSlice, { AuthTokenType } from './slices/authSlice';
-import userSlice, { UserInfoType } from './slices/userSlice';
-import routineSlice, { RoutineType } from './slices/routineSlice';
-import periodSlice, { PeriodType } from './slices/periodSlice';
-
-export interface ReducerStates {
-    auth: AuthTokenType;
-    user: UserInfoType;
-    routine: RoutineType;
-    period: PeriodType;
-}
-
-const rootReducer = (state: ReducerStates, action: AnyAction): CombinedState<ReducerStates> => {
-    switch (action.type) {
-        case HYDRATE:
-            return { ...state, ...action.payload };
-
-        default: {
-            const combinedReducer = combineReducers({
-                auth: authSlice.reducer,
-                user: userSlice.reducer,
-                routine: routineSlice.reducer,
-                period: periodSlice.reducer,
-            });
-            return combinedReducer(state, action);
-        }
-    }
-};
-
-const makeStore = () => {
-    const store = configureStore({
-        reducer: rootReducer as Reducer<ReducerStates, AnyAction>,
-        devTools: process.env.NODE_ENV === 'development',
-    });
-
-    return store;
-};
-
-export type AppStore = ReturnType<typeof makeStore>;
-export type RootState = ReturnType<typeof rootReducer>;
-export type AppDispatch = AppStore['dispatch'];
-
-const wrapper = createWrapper<AppStore>(makeStore, {
-    debug: process.env.NODE_ENV === 'development',
+export const store = configureStore({
+    reducer: {
+        auth: authSlice,
+        period: periodSlice,
+        routine: routineSlice,
+        user: userSlice,
+    },
+    devTools: process.env.NODE_ENV !== 'production',
 });
 
-export default wrapper;
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Title #225 
- redux toolkit legacy update, 카카오 회원가입 후 '/' 경로로 이동 안되는 버그

## Description
- redux toolkit legacy update

## 버그가 있던 부분 Desc
'/' 경로의 Server Side
- localStorage에 'access_token'이라는 key 값이 있으면 '/home'으로 redirect [로그인 후 '/' 경로로 가는거 막기 위한]

'/home' 경로의 Server Side
  - browser cookie에 refresh_token이 없으면 '/' 경로로 redirect

Loading 컴포넌트
- 카카오 아이디로 가입한 회원이던 아니던 일단 localStorage, browser cookie 에 토큰 저장 하는게 문제였다.
  카카오 아이디로 가입한적 없는 회원이면 /signup/kakao로 redirect 시킨후 회원가입 버튼을 클릭하면 '/' 경로로 redirect 된다.
 하지만 '/' server side에서는 token key 값의 존재여부로 '/home'으로 redirect 그런데 '/home'에서는 token "값"이 없으면
 '/'로 redirect 시킨다. 이 부분이 무한 반복되는 문제가 생겼기 때문에 Loading 컴포넌트에서 '/home' 경로로 가는 경우에만 token, browser cookie에 저장 시키도록 로직 변경