### PR TITLE
Bug/232 homedetail likebutton

### DIFF
--- a/src/apis/apiService.ts
+++ b/src/apis/apiService.ts
@@ -99,10 +99,6 @@ export const EditUserInfo = async (editedUserInfoData: ProfileInfoEditType) => {
     return await instanceAuthenticated.patch(`${MYPAGE.MYPAGE_UPDATE}`, editedUserInfoData);
 };
 
-export const CheckRoutineIsSaved = async (routineId: string) => {
-    return await instanceAuthenticated.get(`${EXERCISE.EXERCISE_ENROLLED}/${routineId}`);
-};
-
 export const LikePost = async (routineId: number | undefined) => {
     return await instanceAuthenticated.post(`${EXERCISE.EXERCISE}/${routineId}${EXERCISE.LIKES}`);
 };

--- a/src/common/molecules/LikeControl.tsx
+++ b/src/common/molecules/LikeControl.tsx
@@ -46,6 +46,10 @@ const LikeControl = ({ id, liked, handleLikeList }: LikeControlType) => {
     };
 
     useEffect(() => {
+        setIsLike(liked);
+    }, [liked]);
+
+    useEffect(() => {
         handleLikeList?.();
     }, [isLike]);
 

--- a/src/common/molecules/RoutineCard.tsx
+++ b/src/common/molecules/RoutineCard.tsx
@@ -41,7 +41,7 @@ const RoutineCard = ({ id, imgpath, period, enrolled, fewTime, routineName, cate
                     <Link
                         href={{
                             pathname: `${pathName.includes('/mypage') ? '/home' : pathName}/detail/[slug]`,
-                            query: { slug: DeletedBlankRoutineName, liked: liked, routineId: id, period, weekProgress },
+                            query: { slug: DeletedBlankRoutineName, routineId: id, period, weekProgress },
                         }}
                     >
                         <RC.span>{routineName}</RC.span>

--- a/src/components/home/detail/index.tsx
+++ b/src/components/home/detail/index.tsx
@@ -6,7 +6,7 @@ import CreateButton from '@/common/molecules/CreateButton';
 import LikeControl from '@/common/molecules/LikeControl';
 import RoutineDetail from '../RoutineDetail';
 
-import { CheckRoutineIsSaved, GetDetailRoutine, SaveRoutineInfo } from '@/apis/apiService';
+import { GetDetailRoutine, SaveRoutineInfo } from '@/apis/apiService';
 import useAddOptions from '@/hooks/useAddOptions';
 import { useAppDispatch, useAppSelector } from '@/store/hook';
 import getErrorMessage from '@/utils/getErrorMessage';
@@ -42,9 +42,10 @@ const HomeDetail = ({ props: { converted_routine_id } }: InferGetServerSideProps
     const saveRoutineInformation = (response: DetailRoutineType) => {
         const { result } = response.data;
         const [routine_information]: ResultType = result;
-        const { routineName, period, days, isliked } = routine_information;
+        const { routineName, period, days, isliked, isenrolled } = routine_information;
 
         setIsLiked(isliked);
+        setIsSaved(isenrolled);
 
         const dayPerWeek = days.length;
 
@@ -87,21 +88,6 @@ const HomeDetail = ({ props: { converted_routine_id } }: InferGetServerSideProps
     useEffect(() => {
         getRoutineDetailInfo();
     }, [week]);
-
-    useEffect(() => {
-        const getRoutineIsSave = async () => {
-            try {
-                const response = await CheckRoutineIsSaved(converted_routine_id);
-                const { success } = response.data;
-
-                setIsSaved(success);
-            } catch (error) {
-                console.log('등록안됨');
-            }
-        };
-
-        getRoutineIsSave();
-    }, [isSaved]);
 
     return (
         <HD.Box>

--- a/src/components/home/detail/index.tsx
+++ b/src/components/home/detail/index.tsx
@@ -18,10 +18,11 @@ import { DetailRoutineType, ResultType } from '../type';
 import { InferGetServerSidePropsType } from 'next/types';
 import { getServerSideProps } from '@/pages/home/detail/[slug]';
 
-const HomeDetail = ({ props: { converted_routine_id, converted_liked } }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const HomeDetail = ({ props: { converted_routine_id } }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     const [overviewInformation, setOverviewInformation] = useState({ routineName: '', programLength: 0, dayPerWeek: 0 });
     const [routineSlideList, setRoutineSlideList] = useState([]);
     const [isSaved, setIsSaved] = useState(false);
+    const [isLiked, setIsLiked] = useState(false);
 
     const dispatch = useAppDispatch();
     const router = useRouter();
@@ -41,7 +42,9 @@ const HomeDetail = ({ props: { converted_routine_id, converted_liked } }: InferG
     const saveRoutineInformation = (response: DetailRoutineType) => {
         const { result } = response.data;
         const [routine_information]: ResultType = result;
-        const { routineName, period, days } = routine_information;
+        const { routineName, period, days, isliked } = routine_information;
+
+        setIsLiked(isliked);
 
         const dayPerWeek = days.length;
 
@@ -143,7 +146,7 @@ const HomeDetail = ({ props: { converted_routine_id, converted_liked } }: InferG
                     </HD.RoutineSlideBox>
                 </HD.RoutineMain>
                 <HD.FooterBox>
-                    <LikeControl id={converted_routine_id} liked={converted_liked} />
+                    <LikeControl id={converted_routine_id} liked={isLiked} />
                     <CreateButton handleSubmit={handleSaveRoutine} message="등록하기" isSaved={isSaved} />
                 </HD.FooterBox>
             </HD.RoutineDescBox>

--- a/src/components/home/type.ts
+++ b/src/components/home/type.ts
@@ -9,6 +9,7 @@ type ResponseResult = {
     period: number;
     weeks: number;
     days: daysType;
+    isliked: boolean;
 };
 
 type ResultType = ResponseResult[];

--- a/src/components/home/type.ts
+++ b/src/components/home/type.ts
@@ -10,6 +10,7 @@ type ResponseResult = {
     weeks: number;
     days: daysType;
     isliked: boolean;
+    isenrolled: boolean;
 };
 
 type ResultType = ResponseResult[];

--- a/src/pages/home/detail/[slug].tsx
+++ b/src/pages/home/detail/[slug].tsx
@@ -12,7 +12,7 @@ HomeDetailPage.getLayout = function getLayout(page: ReactElement) {
 };
 
 export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
-    const { routineId, liked } = ctx.query;
+    const { routineId } = ctx.query;
     const { cookies } = ctx.req;
 
     if (!cookies.refresh_token) {
@@ -25,15 +25,12 @@ export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSideP
     }
 
     const assure_routine_id = routineId as string;
-    const assure_liked = liked as string;
 
     const converted_routine_id = parseInt(assure_routine_id);
-    const converted_liked = Boolean(assure_liked);
 
     return {
         props: {
             converted_routine_id,
-            converted_liked,
         },
     };
 };


### PR DESCRIPTION
## Title #232 
- /home/detail 좋아요 상태
- /home/detail 저장된 루틴인지 api 호출 삭제

## Description
기존
- /home/detail 좋아요 상태
  - 기존에는 좋아요 조회 api를 사용해서 했다. 하지만 /home/detail에 접근시 id 값에 따른 운동루틴에 모든 정보를 가져온다. 이 정보중에서 isliked 값을 사용하여 좋아요 표시
  - 위와 같이 등록된 루틴인지도 알려주는 isenrolled 값을 사용하여 "등록하기" 버튼 표시
