### PR TITLE
Modal기능 커스텀 훅으로 분리

### DIFF
--- a/src/components/save/detail/ExerciseDetailMain.tsx
+++ b/src/components/save/detail/ExerciseDetailMain.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 
+import { createPortal } from 'react-dom';
+import { useRouter } from 'next/router';
+
 import ExerciseDetail from './ExerciseDetail';
 import CreateButton from '@/common/molecules/CreateButton';
 import PagiNation from '@/common/molecules/PagiNation';
@@ -9,23 +12,20 @@ import BackDrop from '@/common/molecules/BackDrop';
 import { RoutineSuccess, SaveRoutineDetail } from '@/apis/apiService';
 import getErrorMessage from '@/utils/getErrorMessage';
 import { convertToNumber } from '@/utils/convertToNumber';
+import { filteringMapObject } from '@/utils/filteringMapObject';
+import useModal from '@/hooks/useModal';
 
 import { BB } from '../style';
-import { useRouter } from 'next/router';
-import { ModalType } from '../type';
-import { createPortal } from 'react-dom';
-import { filteringMapObject } from '@/utils/filteringMapObject';
 interface ExerciseDetailMain {
     routineId: string;
 }
 
 const ExerciseDetailMain = ({ routineId }: ExerciseDetailMain) => {
     const [today, setToday] = useState('Mon');
-    const [portalElement, setPortalElement] = useState<ModalType>(null);
-    const [backDropElement, setBackDropElement] = useState<ModalType>(null);
-    const [isModal, setIsModal] = useState(false);
     const [successByDay, setSuccessByDay] = useState<Map<string, boolean>>(new Map());
     const [week, setWeek] = useState(1);
+
+    const { isModal, updateIsModal, portalElement, backDropElement } = useModal();
 
     const router = useRouter();
 
@@ -36,7 +36,7 @@ const ExerciseDetailMain = ({ routineId }: ExerciseDetailMain) => {
     };
 
     const moveMypage = () => {
-        setIsModal(prev => !prev);
+        updateIsModal(true);
 
         setTimeout(() => {
             router.replace('/mypage');
@@ -82,11 +82,6 @@ const ExerciseDetailMain = ({ routineId }: ExerciseDetailMain) => {
 
     useEffect(() => {
         fetchSuccess();
-    }, []);
-
-    useEffect(() => {
-        setPortalElement(document.getElementById('portal'));
-        setBackDropElement(document.getElementById('back-drop'));
     }, []);
 
     return (

--- a/src/components/save/detail/index.tsx
+++ b/src/components/save/detail/index.tsx
@@ -1,9 +1,10 @@
-import { getServerSideProps } from '@/pages/save/detail/[slug]';
-
 import { InferGetServerSidePropsType } from 'next/types';
 
-import { BB } from '../style';
 import ExerciseDetailMain from './ExerciseDetailMain';
+
+import { getServerSideProps } from '@/pages/save/detail/[slug]';
+
+import { BB } from '../style';
 
 const SaveDetail = ({ props: { data } }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     const { period, routineId, slug } = data;

--- a/src/components/save/index.tsx
+++ b/src/components/save/index.tsx
@@ -10,18 +10,17 @@ import BackDrop from '@/common/molecules/BackDrop';
 import { DeleteRoutine, MainSave } from '@/apis/apiService';
 import { SelectOptions } from '@/data/SaveData';
 import getErrorMessage from '@/utils/getErrorMessage';
+import useModal from '@/hooks/useModal';
 
 import { SV } from './style';
 import WeightIcon from '../../../public/assets/weight-icon.svg';
 import { RoutineProps } from '../../common/molecules/type';
-import { ModalType } from './type';
 
 const Save = () => {
     const [selectedValue, setSelectedValue] = useState<string>('all');
     const [saveData, setSaveData] = useState<RoutineProps[]>([]);
-    const [deleteResponse, setDeleteResponse] = useState(false);
-    const [portalElement, setPortalElement] = useState<ModalType>(null);
-    const [backDropElement, setBackDropElement] = useState<ModalType>(null);
+
+    const { isModal, updateIsModal, portalElement, backDropElement } = useModal();
 
     const handleSave = async (category: string) => {
         try {
@@ -35,10 +34,10 @@ const Save = () => {
     };
 
     const handleDeleteRoutine = async (id: number | undefined) => {
-        setDeleteResponse(true);
+        updateIsModal(true);
         try {
             const response = await DeleteRoutine(id);
-            setDeleteResponse(false);
+            updateIsModal(false);
             handleSave(selectedValue);
 
             return response;
@@ -50,11 +49,6 @@ const Save = () => {
     const handleChangeCategory = (categoryData: string) => {
         setSelectedValue(categoryData);
     };
-
-    useEffect(() => {
-        setPortalElement(document.getElementById('portal'));
-        setBackDropElement(document.getElementById('back-drop'));
-    }, []);
 
     useEffect(() => {
         handleSave(selectedValue);
@@ -90,8 +84,8 @@ const Save = () => {
                     ))}
                 </SV.CardList>
             )}
-            {portalElement && deleteResponse ? createPortal(<RoutineModal />, portalElement) : null}
-            {backDropElement && deleteResponse ? createPortal(<BackDrop />, backDropElement) : null}
+            {portalElement && isModal ? createPortal(<RoutineModal />, portalElement) : null}
+            {backDropElement && isModal ? createPortal(<BackDrop />, backDropElement) : null}
         </SV.Box>
     );
 };

--- a/src/components/save/type.ts
+++ b/src/components/save/type.ts
@@ -48,8 +48,6 @@ type SaveRoutineInfo = {
     ];
 };
 
-type ModalType = Element | null;
-
 type RoutineItemType = {
     sequence: number;
     weight: number;
@@ -57,4 +55,4 @@ type RoutineItemType = {
     id: number;
 };
 
-export type { SelectType, RoutineType, TodayExercisesType, ModalType, SaveRoutineInfo, RoutineItemType };
+export type { SelectType, RoutineType, TodayExercisesType, SaveRoutineInfo, RoutineItemType };

--- a/src/hooks/type.ts
+++ b/src/hooks/type.ts
@@ -1,0 +1,1 @@
+export type ModalType = Element | null;

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import { ModalType } from './type';
+
+const useModal = () => {
+    const [isModal, setIsModal] = useState(false);
+    const [portalElement, setPortalElement] = useState<ModalType>(null);
+    const [backDropElement, setBackDropElement] = useState<ModalType>(null);
+
+    const updateIsModal = (modalState: boolean) => {
+        setIsModal(modalState);
+    };
+
+    useEffect(() => {
+        setPortalElement(document.getElementById('portal'));
+        setBackDropElement(document.getElementById('back-drop'));
+    }, []);
+
+    return {
+        isModal,
+        updateIsModal,
+        portalElement,
+        backDropElement,
+    };
+};
+
+export default useModal;


### PR DESCRIPTION
## Title #245 
- Modal 커스텀 훅으로 분리

## Description
- /save, /save/detail에 각각 정의 되어있던 Modal 기능을 커스텀 훅으로 분리함으로써 다른 컴포넌트에서도 재사용 가능
