### PR TITLE
Refactor/248 refresh token middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { TOKEN } from './utils/constants';
+
+export function middleware(request: NextRequest) {
+    const { cookies } = request;
+
+    if (!cookies.get(TOKEN.REFRESH_TOKEN_KEY)) {
+        return NextResponse.redirect(new URL('/', request.nextUrl.origin));
+    }
+}
+
+export const config = {
+    matcher: ['/home/:path*', '/save/:path*', '/post', '/mypage/:path*'],
+};

--- a/src/pages/home/detail/[slug].tsx
+++ b/src/pages/home/detail/[slug].tsx
@@ -1,7 +1,9 @@
 import { ReactElement } from 'react';
+
 import HomeDetail from '@/components/home/detail';
-import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType } from 'next/types';
 import DefaultLayout from '@/common/layout/DefaultLayout';
+
+import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType } from 'next/types';
 
 const HomeDetailPage = (props: InferGetServerSidePropsType<typeof getServerSideProps>) => {
     return <HomeDetail props={props} />;
@@ -13,16 +15,6 @@ HomeDetailPage.getLayout = function getLayout(page: ReactElement) {
 
 export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
     const { routineId } = ctx.query;
-    const { cookies } = ctx.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
 
     const assure_routine_id = routineId as string;
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,7 +1,6 @@
 import DefaultLayout from '@/common/layout/DefaultLayout';
 import Home from '@/components/home';
 
-import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
 import { ReactElement } from 'react';
 
 const HomePage = () => {
@@ -10,23 +9,6 @@ const HomePage = () => {
 
 HomePage.getLayout = function getLayout(page: ReactElement) {
     return <DefaultLayout isHeader={true}>{page}</DefaultLayout>;
-};
-
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-    const { cookies } = context.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
-
-    return {
-        props: {},
-    };
 };
 
 export default HomePage;

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,8 +1,7 @@
+import { ReactElement } from 'react';
+
 import DefaultLayout from '@/common/layout/DefaultLayout';
 import Mypage from '@/components/mypage';
-
-import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
-import { ReactElement } from 'react';
 
 const ProfilePage = () => {
     return <Mypage />;
@@ -10,23 +9,6 @@ const ProfilePage = () => {
 
 ProfilePage.getLayout = function getLayout(page: ReactElement) {
     return <DefaultLayout isHeader={true}>{page}</DefaultLayout>;
-};
-
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-    const { cookies } = context.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
-
-    return {
-        props: {},
-    };
 };
 
 export default ProfilePage;

--- a/src/pages/mypage/likes/index.tsx
+++ b/src/pages/mypage/likes/index.tsx
@@ -2,8 +2,6 @@ import { ReactElement } from 'react';
 
 import MypageLikes from '@/components/mypage/likes';
 
-import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
-import DefaultLayout from '@/common/layout/DefaultLayout';
 import AuthLayout from '@/common/layout/AuthLayout';
 
 const MyPageLikesPage = () => {
@@ -11,28 +9,7 @@ const MyPageLikesPage = () => {
 };
 
 MyPageLikesPage.getLayout = function getLayout(page: ReactElement) {
-    return <DefaultLayout isHeader={true}>{page}</DefaultLayout>;
-};
-
-MyPageLikesPage.getLayout = function getLayout(page: ReactElement) {
     return <AuthLayout isShowPrevBtn={true}>{page}</AuthLayout>;
-};
-
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-    const { cookies } = context.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
-
-    return {
-        props: {},
-    };
 };
 
 export default MyPageLikesPage;

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,8 +1,7 @@
+import { ReactElement } from 'react';
+
 import DefaultLayout from '@/common/layout/DefaultLayout';
 import Posts from '@/components/posts';
-
-import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
-import { ReactElement } from 'react';
 
 const PostPage = () => {
     return <Posts />;
@@ -10,23 +9,6 @@ const PostPage = () => {
 
 PostPage.getLayout = function getLayout(page: ReactElement) {
     return <DefaultLayout isHeader={true}>{page}</DefaultLayout>;
-};
-
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-    const { cookies } = context.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
-
-    return {
-        props: {},
-    };
 };
 
 export default PostPage;

--- a/src/pages/save/index.tsx
+++ b/src/pages/save/index.tsx
@@ -1,7 +1,7 @@
+import { ReactElement } from 'react';
+
 import DefaultLayout from '@/common/layout/DefaultLayout';
 import Save from '@/components/save';
-import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
-import { ReactElement } from 'react';
 
 const SavePage = () => {
     return <Save />;
@@ -9,22 +9,6 @@ const SavePage = () => {
 
 SavePage.getLayout = function getLayout(page: ReactElement) {
     return <DefaultLayout isHeader={true}>{page}</DefaultLayout>;
-};
-export const getServerSideProps: GetServerSideProps = async (context: GetServerSidePropsContext) => {
-    const { cookies } = context.req;
-
-    if (!cookies.refresh_token) {
-        return {
-            redirect: {
-                destination: '/',
-                permanent: false,
-            },
-        };
-    }
-
-    return {
-        props: {},
-    };
 };
 
 export default SavePage;


### PR DESCRIPTION
## Title #248 
- refresh token 값이 없으면 로그인 페이지로 redirect 되는 로직 리팩토링

## Description

기존
- pages에 있는 각각의 파일에서 getServerSideProps로 refresh_token 유무를 판단하여 '/' 경로로 redirect 시켰기 때문에 코드량이 증가했고, 이로 인해 유지보수성이 떨어졌다.

변경 후
- next.js middleware를 사용하여 인증이 필요한 페이지 검증
   - config의 matcher 속성 사용하여 검증이 필요한 페이지 지정
   - middleware 하나의 파일에서  refresh_token 검증로직 관리 가능

